### PR TITLE
[Fix] Fix version 1 remaining problems (2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GID ?= $(shell id -g)
 # Define docker-compose command with production config
 COMPOSE = UID=$(UID) GID=$(GID) docker compose -f docker-compose.prod.yaml -p comicchase-prod
 
-.PHONY: build up down logs shell clean help
+.PHONY: up down build rebuild logs shell manage clean help
 
 .DEFAULT_GOAL := help
 


### PR DESCRIPTION
This pull request makes a minor update to the `Makefile` by adding new targets to the `.PHONY` list. This change improves makefile hygiene and ensures that the new targets are always treated as phony, preventing conflicts with files of the same name.

- Makefile maintenance:
  * Added `rebuild` and `manage` to the `.PHONY` target list in `Makefile` to ensure these targets are always executed as recipes, not as file dependencies.